### PR TITLE
Add os.O_TRUNC flag to os.OpenFile to solve trailing junk issue.

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -217,7 +217,7 @@ func (t *dirTemplate) Execute(dirPrefix string) error {
 				return err
 			}
 
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, fi.Mode())
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fi.Mode())
 			if err != nil {
 				return err
 			}

--- a/pkg/util/osutil/fs.go
+++ b/pkg/util/osutil/fs.go
@@ -97,7 +97,7 @@ func CopyRecursively(srcPath, dstPath string) error {
 			}
 			defer srcf.Close()
 
-			dstf, err := os.OpenFile(mirrorPath, os.O_CREATE|os.O_WRONLY, fi.Mode())
+			dstf, err := os.OpenFile(mirrorPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fi.Mode())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
See https://github.com/tmrts/boilr/pull/63