### PR TITLE
 Fixes issue with static-late-binding inside closures

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -113,31 +113,35 @@ func (t *dirTemplate) UseDefaultValues() {
 }
 
 func (t *dirTemplate) BindPrompts() {
-	for s, v := range t.Context {
-		if m, ok := v.(map[string]interface{}); ok {
-			advancedMode := prompt.New(s, false)
+	for parentKey := range t.Context {
+		if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
+			advancedMode := prompt.New(parentKey, false)
 
-			for k, v2 := range m {
+			for childKey := range childMap {
 				if t.ShouldUseDefaults {
-					t.FuncMap[k] = func() interface{} {
-						switch v2 := v2.(type) {
-						// First is the default value if it's a slice
-						case []interface{}:
-							return v2[0]
-						}
+					t.FuncMap[childKey] = func(val interface{}) func() interface{} {
+						return func() interface{} {
+							switch val := val.(type) {
+							// First is the default value if it's a slice
+							case []interface{}:
+								return val[0]
+							}
 
-						return v2
-					}
+							return val
+						}
+					}(childMap[childKey])
 				} else {
-					v, p := v2, prompt.New(k, v2)
+					childPrompt := prompt.New(childKey, childMap[childKey])
 
-					t.FuncMap[k] = func() interface{} {
-						if val := advancedMode().(bool); val {
-							return p()
+					t.FuncMap[childKey] = func(val interface{}, p func() interface{}) func() interface{} {
+						return func() interface{} {
+							if isAdvanced := advancedMode().(bool); isAdvanced {
+								return p()
+							}
+
+							return val
 						}
-
-						return v
-					}
+					}(t.Context[parentKey], childPrompt)
 				}
 			}
 
@@ -145,17 +149,19 @@ func (t *dirTemplate) BindPrompts() {
 		}
 
 		if t.ShouldUseDefaults {
-			t.FuncMap[s] = func() interface{} {
-				switch v := v.(type) {
-				// First is the default value if it's a slice
-				case []interface{}:
-					return v[0]
-				}
+			t.FuncMap[parentKey] = func(val interface{}) func() interface{} {
+				return func() interface{} {
+					switch val := val.(type) {
+					// First is the default value if it's a slice
+					case []interface{}:
+						return val[0]
+					}
 
-				return v
-			}
+					return val
+				}
+			}(t.Context[parentKey])
 		} else {
-			t.FuncMap[s] = prompt.New(s, v)
+			t.FuncMap[parentKey] = prompt.New(parentKey, t.Context[parentKey])
 		}
 	}
 }


### PR DESCRIPTION
You would see this happen when using the fallowing command: `boilr template use your_template target -f`. Using `-f` means using the defaults without prompting you for input. It would use one of the defaults (the last in the loop) as the value for all replacements.