### PR TITLE
Improvement on nested values

### DIFF
--- a/pkg/boilr/configuration.go
+++ b/pkg/boilr/configuration.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tmrts/boilr/pkg/util/exit"
-	"github.com/tmrts/boilr/pkg/util/osutil"
+	"github.com/Ilyes512/boilr/pkg/util/exit"
+	"github.com/Ilyes512/boilr/pkg/util/osutil"
 )
 
 const (

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -114,54 +114,10 @@ func (t *dirTemplate) UseDefaultValues() {
 
 func (t *dirTemplate) BindPrompts() {
 	for parentKey := range t.Context {
-		if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
-			advancedMode := prompt.New(parentKey, false)
-
-			for childKey := range childMap {
-				if t.ShouldUseDefaults {
-					t.FuncMap[childKey] = func(val interface{}) func() interface{} {
-						return func() interface{} {
-							switch val := val.(type) {
-							// First is the default value if it's a slice
-							case []interface{}:
-								return val[0]
-							}
-
-							return val
-						}
-					}(childMap[childKey])
-				} else {
-					childPrompt := prompt.New(childKey, childMap[childKey])
-
-					t.FuncMap[childKey] = func(val interface{}, p func() interface{}) func() interface{} {
-						return func() interface{} {
-							if isAdvanced := advancedMode().(bool); isAdvanced {
-								return p()
-							}
-
-							return val
-						}
-					}(t.Context[parentKey], childPrompt)
-				}
-			}
-
-			continue
-		}
-
 		if t.ShouldUseDefaults {
-			t.FuncMap[parentKey] = func(val interface{}) func() interface{} {
-				return func() interface{} {
-					switch val := val.(type) {
-					// First is the default value if it's a slice
-					case []interface{}:
-						return val[0]
-					}
-
-					return val
-				}
-			}(t.Context[parentKey])
+			handleBindDefaults(t, parentKey)
 		} else {
-			t.FuncMap[parentKey] = prompt.New(parentKey, t.Context[parentKey])
+			handleBindPrompts(t, parentKey)
 		}
 	}
 }
@@ -261,4 +217,57 @@ func (t *dirTemplate) Execute(dirPrefix string) error {
 
 		return nil
 	})
+}
+
+func handleBindDefaults(t *dirTemplate, parentKey string) {
+	if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
+		for childKey := range childMap {
+
+			t.FuncMap[childKey] = func(val interface{}) func() interface{} {
+				return func() interface{} {
+					switch val := val.(type) {
+					// First is the default value if it's a slice
+					case []interface{}:
+						return val[0]
+					}
+
+					return val
+				}
+			}(childMap[childKey])
+		}
+	} else {
+		t.FuncMap[parentKey] = func(val interface{}) func() interface{} {
+			return func() interface{} {
+				switch val := val.(type) {
+				// First is the default value if it's a slice
+				case []interface{}:
+					return val[0]
+				}
+
+				return val
+			}
+		}(t.Context[parentKey])
+	}
+}
+
+func handleBindPrompts(t *dirTemplate, parentKey string) {
+	if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
+		advancedMode := prompt.New(parentKey, false)
+
+		for childKey := range childMap {
+			childPrompt := prompt.New(childKey, childMap[childKey])
+
+			t.FuncMap[childKey] = func(val interface{}, p func() interface{}) func() interface{} {
+				return func() interface{} {
+					if isAdvanced := advancedMode().(bool); isAdvanced {
+						return p()
+					}
+
+					return val
+				}
+			}(t.Context[parentKey], childPrompt)
+		}
+	} else {
+		t.FuncMap[parentKey] = prompt.New(parentKey, t.Context[parentKey])
+	}
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -221,6 +221,10 @@ func (t *dirTemplate) Execute(dirPrefix string) error {
 
 func handleBindDefaults(t *dirTemplate, parentKey string) {
 	if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
+		if len(childMap) > 0 {
+			t.FuncMap[parentKey] = func() bool { return false }
+		}
+
 		for childKey := range childMap {
 
 			t.FuncMap[childKey] = func(val interface{}) func() interface{} {
@@ -253,6 +257,14 @@ func handleBindDefaults(t *dirTemplate, parentKey string) {
 func handleBindPrompts(t *dirTemplate, parentKey string) {
 	if childMap, ok := t.Context[parentKey].(map[string]interface{}); ok {
 		advancedMode := prompt.New(parentKey, false)
+
+		if len(childMap) > 0 {
+			t.FuncMap[parentKey] = func(a func() interface{}) func() interface{} {
+				return func() interface{} {
+					return advancedMode()
+				}
+			}(advancedMode)
+		}
 
 		for childKey := range childMap {
 			childPrompt := prompt.New(childKey, childMap[childKey])


### PR DESCRIPTION
So boilr has a feature where you could do this:

In your `project.json`:
```json
{
    "Redis": {
        "RedisUsername": "root",
        "RedisPassword": "secret"
    }
}
```

So when you use a template with the above `project.json` it would ask you to set a bool value for `Redis`. If you fill in `true` it will ask you both `RedisUsername` and `RedisPassword` otherwise it wont ask you for your values and use the default. What this PR adds is that the value of `Redis` will also be available as an boolean.
