### PR TITLE
fix(template/metadata.go): explicit import name

### DIFF
--- a/pkg/template/metadata.go
+++ b/pkg/template/metadata.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/docker/go-units"
+	units "github.com/docker/go-units"
 )
 
 // Metadata contains the information for a template.


### PR DESCRIPTION
Since we use `go-units` as `units` let's be explicit in our `import` statement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ilyes512/boilr/24)
<!-- Reviewable:end -->
