### PR TITLE
Respect XDG spec

### DIFF
--- a/pkg/boilr/configuration.go
+++ b/pkg/boilr/configuration.go
@@ -21,6 +21,9 @@ var (
 
 	// Commit hash of the application
 	Commit = "NOT_SET"
+
+	// Respect XDG Base Directory Specification if set
+	XDGHomeDir := os.Getenv("XDG_CONFIG_HOME")
 )
 
 const (
@@ -28,7 +31,11 @@ const (
 	AppName = "boilr"
 
 	// ConfigDirPath is the configuration directory of the application
-	ConfigDirPath = ".config/boilr"
+	if XDGHomeDir == "" {
+		ConfigDirPath = ".config/boilr"
+	} else {
+		ConfigDirPath = "/boilr"
+	}
 
 	// ConfigFileName is the configuration file name of the application
 	ConfigFileName = "config.json"
@@ -76,6 +83,10 @@ func init() {
 	if homeDir == "" {
 		// FIXME is this really necessary?
 		exit.Error(fmt.Errorf("environment variable ${HOME} should be set"))
+	}
+
+	if XDGHomeDir != "" {
+		homeDir = XDGHomeDir
 	}
 
 	Configuration.FilePath = filepath.Join(homeDir, ConfigDirPath, ConfigFileName)

--- a/pkg/cmd/bash_completion.go
+++ b/pkg/cmd/bash_completion.go
@@ -40,7 +40,7 @@ func configureBashCompletion() error {
 source %s
 `
 
-	bashrcText = fmt.Sprintf(bashrcText, filepath.Join("$HOME", boilr.ConfigDirPath, "completion.bash"))
+	bashrcText = fmt.Sprintf(bashrcText, filepath.Join(boilr.Configuration.ConfigDirPath, "completion.bash"))
 
 	if _, err = f.WriteString(bashrcText); err != nil {
 		return err


### PR DESCRIPTION
Respect `$XDG_CONFIG_HOME`, rather than just dump everything in `$HOME/.config` and force things on the user. See also: https://maex.me/2019/12/the-power-of-the-xdg-base-directory-specification