### PR TITLE
fix: migrate goreleaser brews to homebrew_casks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ release:
     owner: Ilyes512
     name: boilr
 
-brews:
+homebrew_casks:
   -
     repository:
       owner: Ilyes512
@@ -49,12 +49,16 @@ brews:
     commit_author:
       name: ilyes[BOT]
       email: ilyes.ahidar@gmail.com
-    directory: Formula
+    directory: Casks
     homepage: https://github.com/Ilyes512/boilr
     description: "Boilerplate template manager that generates files or directories from template repositories"
     license: Apache-2.0
-    test: |
-      system "#{bin}/boilr --version"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/boilr"]
+          end
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

- Replace deprecated `brews` section with `homebrew_casks` (deprecated since goreleaser v2.10)
- Update `directory` from `Formula` to `Casks`
- Remove `test` block (Formula-specific, not applicable to Casks)
- Add `hooks.post.install` to strip the macOS quarantine attribute from the unsigned binary

## Related

Companion PR in the tap repo: Ilyes512/homebrew-boilr#2 (migrate Formula → Cask + add `tap_migrations.json`)